### PR TITLE
Change "Quansight" to "Quansight Labs" everywhere

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Quansight
+Copyright (c) 2020 Quansight Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Python library for manipulating indices of ndarrays.
 
-The documentation for ndindex can be found at https://quansight.github.io/ndindex/
+The documentation for ndindex can be found at https://quansight-labs.github.io/ndindex/
 
 ndindex is a library that allows representing and manipulating objects that
 can be valid indices to numpy arrays, i.e., slices, integers, ellipses,
@@ -66,7 +66,7 @@ True
 array([], shape=(4, 0), dtype=float64)
 ```
 
-See the [documentation](https://quansight.github.io/ndindex/) for full details
+See the [documentation](https://quansight-labs.github.io/ndindex/) for full details
 on what ndindex can do.
 
 ## License

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,7 +22,7 @@ implemented:
 
 The first case in particular may not ever be implemented, as it is considered
 to be a mistake that it is allowed in the first place in the NumPy, so if you
-need it, please [let me know](https://github.com/Quansight/ndindex/issues).
+need it, please [let me know](https://github.com/Quansight-Labs/ndindex/issues).
 
 Additionally, some corner cases of array semantics are either deprecated or
 fixed as bugs in newer versions of NumPy, with some only being fixed in the
@@ -54,7 +54,7 @@ run the ndindex test suite due to the way ndindex tests itself against NumPy.
   `BooleanArray` and `IntegerArray`. There are still many instances where
   `as_subindex()` raises `NotImplementedError` however. If you need support
   for these, please [open an
-  issue](https://github.com/Quansight/ndindex/issues) to let me know.
+  issue](https://github.com/Quansight-Labs/ndindex/issues) to let me know.
 
 - Add a new document to the documentation on [type confusion](type-confusion).
   The document stresses that ndindex types should not be confused with the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,8 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'ndindex'
-copyright = '2020, Quansight'
-author = 'Quansight'
+copyright = '2020, Quansight Labs'
+author = 'Quansight Labs'
 
 
 # -- General configuration ---------------------------------------------------
@@ -74,7 +74,7 @@ html_theme = 'alabaster'
 pygments_style = 'sphinx'
 
 html_theme_options = {
-    'github_user': 'Quansight',
+    'github_user': 'Quansight-Labs',
     'github_repo': 'ndindex',
     'github_banner': False,
     # 'logo': 'logo.jpg',

--- a/docs/index.md
+++ b/docs/index.md
@@ -172,7 +172,7 @@ The following things are not yet implemented, but are planned.
   [SymPy](https://www.sympy.org/).
 
 And more. If there is something you would like to see this library be able to
-do, please [open an issue](https://github.com/quansight/ndindex/issues). Pull
+do, please [open an issue](https://github.com/quansight-labs/ndindex/issues). Pull
 requests are welcome as well.
 
 (testing)=
@@ -206,7 +206,7 @@ There are two primary types of tests that we employ to verify this:
 - Hypothesis tests. Hypothesis is a library that can intelligently check a
   combinatorial search space of inputs. This requires writing hypothesis
   strategies that can generate all the relevant types of indices (see
-  [ndindex/tests/helpers.py](https://github.com/Quansight/ndindex/blob/master/ndindex/tests/helpers.py)).
+  [ndindex/tests/helpers.py](https://github.com/Quansight-Labs/ndindex/blob/master/ndindex/tests/helpers.py)).
   For more information on hypothesis, see
   <https://hypothesis.readthedocs.io/en/latest/index.html>. All tests have
   hypothesis tests, even if they are also tested exhaustively.
@@ -221,9 +221,9 @@ that still fails. For example, a failing exhaustive slice test might give
 to `Slice(-2, -1, -1)`. Another reason for the duplication is that hypothesis
 can sometimes test a slightly expanded test space without any additional
 consequences. For example,
-[`test_slice_reduce_hypothesis()`](https://github.com/Quansight/ndindex/blob/8875637bf223f92672db9292ec537c9d98ae382e/ndindex/tests/test_slice.py#L165)
+[`test_slice_reduce_hypothesis()`](https://github.com/Quansight-Labs/ndindex/blob/8875637bf223f92672db9292ec537c9d98ae382e/ndindex/tests/test_slice.py#L165)
 in tests all types of array shapes, whereas
-[`test_slice_reduce_exhaustive()`](https://github.com/Quansight/ndindex/blob/8875637bf223f92672db9292ec537c9d98ae382e/ndindex/tests/test_slice.py#L142)
+[`test_slice_reduce_exhaustive()`](https://github.com/Quansight-Labs/ndindex/blob/8875637bf223f92672db9292ec537c9d98ae382e/ndindex/tests/test_slice.py#L142)
 tests only 1-dimensional shapes. This doesn't affect things because hypotheses
 will always shrink large shapes to a 1-dimensional shape in the case of a
 failure. Consequently every exhaustive test will also have a corresponding

--- a/docs/slices.md
+++ b/docs/slices.md
@@ -1682,7 +1682,7 @@ hard to write slice arithmetic. The arithmetic is already hard enough due to
 the modular nature of `step`, but the discontinuous aspect of `start` and
 `stop` increases this tenfold. If you are unconvinced of this, take a look at
 the [source
-code](https://github.com/Quansight/ndindex/blob/master/ndindex/slice.py) for
+code](https://github.com/Quansight-labs/ndindex/blob/master/ndindex/slice.py) for
 `ndindex.Slice()`. You will see lots of nested `if` blocks.[^source-footnote]
 This is because slices have *fundamentally* different definitions if the
 `start` or `stop` are `None`, negative, or nonnegative. Furthermore, `None` is

--- a/docs/type-confusion.md
+++ b/docs/type-confusion.md
@@ -166,7 +166,7 @@ Some general types to help avoid type confusion:
   manipulating index args directly in complex ways, it's a sign you should
   probably be using a higher level abstraction. If what you are trying to do
   doesn't exist yet, [open an
-  issue](https://github.com/Quansight/ndindex/issues) so we can implement it.
+  issue](https://github.com/Quansight-labs/ndindex/issues) so we can implement it.
 
 Additionally, some advice for specific types:
 

--- a/ndindex/tuple.py
+++ b/ndindex/tuple.py
@@ -247,7 +247,7 @@ class Tuple(NDIndex):
         >>> a[1]
         1
 
-        See https://github.com/Quansight/ndindex/issues/22.
+        See https://github.com/Quansight-Labs/ndindex/issues/22.
 
         See Also
         ========

--- a/rever.xsh
+++ b/rever.xsh
@@ -49,7 +49,7 @@ $ACTIVITIES = [
     'ghrelease',  # Creates a Github release entry for the new tag
 ]
 
-$PUSH_TAG_REMOTE = 'git@github.com:Quansight/ndindex.git'  # Repo to push tags to
+$PUSH_TAG_REMOTE = 'git@github.com:Quansight-Labs/ndindex.git'  # Repo to push tags to
 
-$GITHUB_ORG = 'Quansight'  # Github org for Github releases and conda-forge
+$GITHUB_ORG = 'Quansight-Labs'  # Github org for Github releases and conda-forge
 $GITHUB_REPO = 'ndindex'  # Github repo for Github releases and conda-forge

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ setuptools.setup(
     name="ndindex",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    author="Quansight",
+    author="Quansight Labs",
     description="A Python library for manipulating indices of ndarrays.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://quansight.github.io/ndindex/",
+    url="https://quansight-labs.github.io/ndindex/",
     packages=['ndindex', 'ndindex.tests'],
     license="MIT",
     install_requires=[


### PR DESCRIPTION
I'm not sure if we need to update the doctr deploy key. We'll need to first
see if Travis still works at all after the repo move.

Fixes #98.