### PR TITLE
Add new method containing_block() to ChunkSize

### DIFF
--- a/ndindex/chunking.py
+++ b/ndindex/chunking.py
@@ -386,6 +386,10 @@ class ChunkSize(ImmutableObject, Sequence):
         self_ = iter(self)
         shape_ = iter(shape)
         res = []
+
+        if False in idx.args:
+            return Tuple(*[slice(0, 0, 1) for i in range(len(shape))])
+
         while True:
             try:
                 i = next(idx_args)
@@ -406,8 +410,6 @@ class ChunkSize(ImmutableObject, Sequence):
                 if i.step < 0:
                     raise NotImplementedError("containing_block() is not implemented for slices with negative step")
                 res.append(Slice(i.start - (i.start % n), ceiling(i.stop, n)*n))
-            elif i == False:
-                res.append(Slice(0, 0))
             else:
                 raise NotImplementedError(f"containing_block() is not implemented for {type(i).__name__}")
 

--- a/ndindex/chunking.py
+++ b/ndindex/chunking.py
@@ -337,7 +337,7 @@ class ChunkSize(ImmutableObject, Sequence):
 
         return res
 
-    def block(self, idx, shape):
+    def containing_block(self, idx, shape):
         """
         Compute the index for the smallest block that contains `idx` on an array of shape `shape`.
 
@@ -356,7 +356,7 @@ class ChunkSize(ImmutableObject, Sequence):
         >>> chunk_size = ChunkSize((10, 15))
         >>> idx = (slice(0, 12), 40)
         >>> shape = (100, 100)
-        >>> block = chunk_size.block(idx, shape)
+        >>> block = chunk_size.containing_block(idx, shape)
         >>> block
         Tuple(slice(0, 20, 1), slice(30, 45, 1))
 
@@ -404,11 +404,11 @@ class ChunkSize(ImmutableObject, Sequence):
                 res.append(Slice(m//n*n, (M//n + 1)*n))
             elif isinstance(i, Slice):
                 if i.step < 0:
-                    raise NotImplementedError("block() is not implemented for slices with negative step")
+                    raise NotImplementedError("containing_block() is not implemented for slices with negative step")
                 res.append(Slice(i.start - (i.start % n), ceiling(i.stop, n)*n))
             elif i == False:
                 res.append(Slice(0, 0))
             else:
-                raise NotImplementedError(f"block() is not implemented for {type(i).__name__}")
+                raise NotImplementedError(f"containing_block() is not implemented for {type(i).__name__}")
 
         return Tuple(*res).expand(shape)

--- a/ndindex/chunking.py
+++ b/ndindex/chunking.py
@@ -384,7 +384,6 @@ class ChunkSize(ImmutableObject, Sequence):
 
         idx_args = iter(idx.args)
         self_ = iter(self)
-        shape_ = iter(shape)
         res = []
 
         if False in idx.args:
@@ -396,15 +395,17 @@ class ChunkSize(ImmutableObject, Sequence):
                 if isinstance(i, Newaxis) or i == True:
                     continue
                 n = next(self_)
-                s = next(shape_)
             except StopIteration:
                 break
             if isinstance(i, Integer):
                 chunk_n = i.raw//n
                 res.append(Slice(chunk_n*n, (chunk_n + 1)*n))
             elif isinstance(i, IntegerArray):
-                m = np.min(i.array, initial=0)
-                M = np.max(i.array, initial=s)
+                if i.size == 0:
+                    res.append(Slice(0, 0))
+                    continue
+                m = np.min(i.array)
+                M = np.max(i.array)
                 res.append(Slice(m//n*n, (M//n + 1)*n))
             elif isinstance(i, Slice):
                 if i.step < 0:

--- a/ndindex/chunking.py
+++ b/ndindex/chunking.py
@@ -238,7 +238,7 @@ class ChunkSize(ImmutableObject, Sequence):
         while True:
             try:
                 i = next(idx_args)
-                if isinstance(i, Newaxis):
+                if isinstance(i, Newaxis) or i == True:
                     continue
                 n = next(self_)
             except StopIteration:
@@ -315,7 +315,7 @@ class ChunkSize(ImmutableObject, Sequence):
         while True:
             try:
                 i = next(idx_args)
-                if isinstance(i, Newaxis):
+                if isinstance(i, Newaxis) or i == True:
                     continue
                 n = next(self_)
             except StopIteration:
@@ -387,7 +387,7 @@ class ChunkSize(ImmutableObject, Sequence):
         while True:
             try:
                 i = next(idx_args)
-                if isinstance(i, Newaxis):
+                if isinstance(i, Newaxis) or i == True:
                     continue
                 n = next(self_)
                 s = next(shape_)
@@ -402,6 +402,8 @@ class ChunkSize(ImmutableObject, Sequence):
                 res.append(Slice(m//n*n, (M//n + 1)*n))
             elif isinstance(i, Slice) and i.step > 0:
                 res.append(Slice(i.start - (i.start % n), ceiling(i.stop, n)*n))
+            elif i == False:
+                res.append(Slice(0, 0))
             else:
                 raise NotImplementedError
 

--- a/ndindex/chunking.py
+++ b/ndindex/chunking.py
@@ -354,8 +354,25 @@ class ChunkSize(ImmutableObject, Sequence):
         >>> chunk_size = ChunkSize((10, 15))
         >>> idx = (slice(0, 12), 40)
         >>> shape = (100, 100)
-        >>> chunk_size.block(idx, shape)
+        >>> block = chunk_size.block(idx, shape)
+        >>> block
         Tuple(slice(0, 20, 1), slice(30, 45, 1))
+
+        The method :meth:`as_subchunks` can be used on the block to determine
+        which chunks are contained in it, and :meth:`num_subchunks` to
+        determine how many:
+
+        >>> chunk_size.num_subchunks(block, shape)
+        2
+        >>> for c in chunk_size.as_subchunks(block, shape):
+        ...     print(c)
+        Tuple(slice(0, 10, 1), slice(30, 45, 1))
+        Tuple(slice(10, 20, 1), slice(30, 45, 1))
+
+        In this example, `chunk_size.as_subchunk(block, shape)` and
+        `chunk_size.as_subchunks(idx, shape)` are the same, but in general, a
+        block may overlap with more chunks than the original index because the
+        block is contiguous.
 
         """
         shape = asshape(shape)

--- a/ndindex/chunking.py
+++ b/ndindex/chunking.py
@@ -324,7 +324,9 @@ class ChunkSize(ImmutableObject, Sequence):
                 continue
             elif isinstance(i, IntegerArray):
                 res *= np.unique(i.array//n).size
-            elif isinstance(i, Slice) and i.step > 0:
+            elif isinstance(i, Slice):
+                if i.step < 0:
+                    raise NotImplementedError("num_subchunks() is not implemented for slices with negative step")
                 a, N, m = i.args
                 if m > n:
                     res *= ceiling(N-a, m)
@@ -400,11 +402,13 @@ class ChunkSize(ImmutableObject, Sequence):
                 m = np.min(i.array, initial=0)
                 M = np.max(i.array, initial=s)
                 res.append(Slice(m//n*n, (M//n + 1)*n))
-            elif isinstance(i, Slice) and i.step > 0:
+            elif isinstance(i, Slice):
+                if i.step < 0:
+                    raise NotImplementedError("block() is not implemented for slices with negative step")
                 res.append(Slice(i.start - (i.start % n), ceiling(i.stop, n)*n))
             elif i == False:
                 res.append(Slice(0, 0))
             else:
-                raise NotImplementedError
+                raise NotImplementedError(f"block() is not implemented for {type(i).__name__}")
 
         return Tuple(*res).expand(shape)

--- a/ndindex/tests/test_chunking.py
+++ b/ndindex/tests/test_chunking.py
@@ -200,7 +200,7 @@ def test_num_subchunks_error():
     raises(ValueError, lambda: next(ChunkSize((1, 2)).num_subchunks(..., (1, 2, 3))))
 
 @given(chunk_sizes(), ndindices, chunk_shapes)
-def test_block(chunk_size, idx, shape):
+def test_containing_block(chunk_size, idx, shape):
     chunk_size = ChunkSize(chunk_size)
     idx = ndindex(idx)
 
@@ -213,7 +213,7 @@ def test_block(chunk_size, idx, shape):
         assume(False)
 
     try:
-        block = chunk_size.block(idx, shape)
+        block = chunk_size.containing_block(idx, shape)
     except NotImplementedError:
         return
 

--- a/ndindex/tests/test_chunking.py
+++ b/ndindex/tests/test_chunking.py
@@ -200,6 +200,7 @@ def test_num_subchunks(chunk_size, idx, shape):
 def test_num_subchunks_error():
     raises(ValueError, lambda: next(ChunkSize((1, 2)).num_subchunks(..., (1, 2, 3))))
 
+@example((5,), [0, 7], (15,))
 @given(chunk_sizes(), ndindices, chunk_shapes)
 def test_containing_block(chunk_size, idx, shape):
     chunk_size = ChunkSize(chunk_size)

--- a/ndindex/tests/test_chunking.py
+++ b/ndindex/tests/test_chunking.py
@@ -229,3 +229,6 @@ def test_containing_block(chunk_size, idx, shape):
     a_block = a[block.raw]
 
     assert np_all(isin(a_idx, a_block))
+
+def test_containing_block_error():
+    raises(ValueError, lambda: ChunkSize((1, 2)).containing_block(..., (1, 2, 3)))

--- a/ndindex/tests/test_chunking.py
+++ b/ndindex/tests/test_chunking.py
@@ -200,7 +200,9 @@ def test_num_subchunks(chunk_size, idx, shape):
 def test_num_subchunks_error():
     raises(ValueError, lambda: next(ChunkSize((1, 2)).num_subchunks(..., (1, 2, 3))))
 
+
 @example((5,), [0, 7], (15,))
+@example((5,), [], (15,))
 @given(chunk_sizes(), ndindices, chunk_shapes)
 def test_containing_block(chunk_size, idx, shape):
     chunk_size = ChunkSize(chunk_size)

--- a/ndindex/tests/test_chunking.py
+++ b/ndindex/tests/test_chunking.py
@@ -171,9 +171,6 @@ def test_as_subchunks(chunk_size, idx, shape):
         elements = arange(0)
     assert_equal(sort(elements), sort(full_idx.flatten()))
 
-def test_num_subchunks_error():
-    raises(ValueError, lambda: next(ChunkSize((1, 2)).num_subchunks(..., (1, 2, 3))))
-
 @example(chunk_size=(1,), idx=None, shape=(1,))
 @example((1,), True, (1,))
 @example(chunk_size=(1, 1), idx=slice(1, None, 2), shape=(4, 1))
@@ -198,6 +195,9 @@ def test_num_subchunks(chunk_size, idx, shape):
     except NotImplementedError:
         return
     assert computed_num_subchunks == actual_num_subchunks
+
+def test_num_subchunks_error():
+    raises(ValueError, lambda: next(ChunkSize((1, 2)).num_subchunks(..., (1, 2, 3))))
 
 @given(chunk_sizes(), ndindices, chunk_shapes)
 def test_block(chunk_size, idx, shape):

--- a/ndindex/tests/test_chunking.py
+++ b/ndindex/tests/test_chunking.py
@@ -104,6 +104,7 @@ def test_indices(chunk_size, shape):
     elements = [i for x in subarrays for i in x.flatten()]
     assert sorted(elements) == list(range(size))
 
+@example(chunk_size=(1,), idx=slice(None, None, -1), shape=(2,))
 @example((1,), True, (1,))
 @example(chunk_size=(1, 1), idx=slice(1, None, 2), shape=(4, 1))
 @example((1,), ..., (0,))

--- a/ndindex/tests/test_chunking.py
+++ b/ndindex/tests/test_chunking.py
@@ -220,11 +220,11 @@ def test_containing_block(chunk_size, idx, shape):
 
     assert isinstance(block, Tuple), block
     assert len(block.args) == len(chunk_size)
-    assert all(isinstance(i, Slice) for i in block.args)
-    assert all(i.start >= 0 and i.start % n == 0 for i, n in zip(block.args, chunk_size)), block
-    assert all(i.stop >= 0 and (i.stop == s or i.stop % n == 0) for i, s, n in
-               zip(block.args, shape, chunk_size)), block
-    assert all(i.step == 1 for i in block.args), block
+    assert all(isinstance(s, Slice) for s in block.args)
+    assert all(s.start >= 0 and s.start % n == 0 for s, n in zip(block.args, chunk_size)), block
+    assert all(s.stop >= 0 and (s.stop == i or s.stop % n == 0) and s.stop <=
+               i for s, i, n in zip(block.args, shape, chunk_size)), block
+    assert all(s.step == 1 for s in block.args), block
 
     a_idx = a[idx.raw]
     a_block = a[block.raw]

--- a/ndindex/tests/test_chunking.py
+++ b/ndindex/tests/test_chunking.py
@@ -104,9 +104,6 @@ def test_indices(chunk_size, shape):
     elements = [i for x in subarrays for i in x.flatten()]
     assert sorted(elements) == list(range(size))
 
-def test_as_subchunks_error():
-    raises(ValueError, lambda: next(ChunkSize((1, 2)).as_subchunks(..., (1, 2, 3))))
-
 @example((1,), True, (1,))
 @example(chunk_size=(1, 1), idx=slice(1, None, 2), shape=(4, 1))
 @example((1,), ..., (0,))
@@ -170,6 +167,9 @@ def test_as_subchunks(chunk_size, idx, shape):
     else:
         elements = arange(0)
     assert_equal(sort(elements), sort(full_idx.flatten()))
+
+def test_as_subchunks_error():
+    raises(ValueError, lambda: next(ChunkSize((1, 2)).as_subchunks(..., (1, 2, 3))))
 
 @example(chunk_size=(1,), idx=None, shape=(1,))
 @example((1,), True, (1,))


### PR DESCRIPTION
containing_block() computes the smallest block of contiguous chunks containing an index.