### PR TITLE
add optional cythonization

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -70,6 +70,23 @@ their limitations:
   don't have to try to figure out all the different cases yourself. And due to
   extensive testing (see below), you can be assured that ndindex is correct.
 
+## Installation
+
+ndindex can be installed using pip (`pip install ndindex`).
+When installing ndindex from source (using `python setup.py install`) all
+Python modules (except tests) will be cythonized when Cython and a working
+compiler are installed.  The environment variable `CYTHONIZE_NDINDEX` is
+used to explicitly control this default behavior:
+
+- `CYTHONIZE_NDINDEX=0`: disables cythonization (even if a
+  working Cython environment is available)
+
+- `CYTHONIZE_NDINDEX=1`: force cythonization (will fail when Cython or a
+  compiler isn't present)
+
+- `CYTHONIZE_NDINDEX` not set: the default behavior
+
+
 ## Features
 
 ndindex is still a work in progress. The following things are currently

--- a/setup.py
+++ b/setup.py
@@ -25,17 +25,17 @@ def check_cython():
         sys.argv = argv_org
     return True
 
-
-if os.getenv("CYTHONIZE_NDINDEX") is None:
-    CYTHONIZE_NDINDEX = check_cython()
+CYTHONIZE_NDINDEX = os.getenv("CYTHONIZE_NDINDEX")
+if CYTHONIZE_NDINDEX is None:
+    use_cython = check_cython()
 else:
     try:
-        CYTHONIZE_NDINDEX = bool(int(os.getenv("CYTHONIZE_NDINDEX")))
+        use_cython = bool(int(CYTHONIZE_NDINDEX))
     except ValueError:
         sys.exit("Acceptable values for CYTHONIZE_NDINDEX are '0' and '1', "
-                 "got: %r" % os.getenv("CYTHONIZE_NDINDEX"))
+                 "got: %r" % CYTHONIZE_NDINDEX)
 
-if CYTHONIZE_NDINDEX:
+if use_cython:
     from Cython.Build import cythonize
     ext_modules = cythonize(["ndindex/*.py"])
 else:

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,19 @@
+import os
 import setuptools
 import versioneer
+try:
+    from Cython.Build import cythonize
+except ImportError:
+    cythonize = None
+
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
+
+if cythonize and os.getenv("CYTHONIZE_NDINDEX"):
+    ext_modules = list(cythonize(["ndindex/*.py"]))
+else:
+    ext_modules = []
 
 setuptools.setup(
     name="ndindex",
@@ -14,6 +25,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://quansight-labs.github.io/ndindex/",
     packages=['ndindex', 'ndindex.tests'],
+    ext_modules = ext_modules,
     license="MIT",
     install_requires=[
         "numpy",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,11 @@ def check_cython():
 if os.getenv("CYTHONIZE_NDINDEX") is None:
     CYTHONIZE_NDINDEX = check_cython()
 else:
-    CYTHONIZE_NDINDEX = bool(int(os.getenv("CYTHONIZE_NDINDEX")))
+    try:
+        CYTHONIZE_NDINDEX = bool(int(os.getenv("CYTHONIZE_NDINDEX")))
+    except ValueError:
+        sys.exit("Acceptable values for CYTHONIZE_NDINDEX are '0' and '1', "
+                 "got: %r" % os.getenv("CYTHONIZE_NDINDEX"))
 
 if CYTHONIZE_NDINDEX:
     from Cython.Build import cythonize
@@ -47,7 +51,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://quansight-labs.github.io/ndindex/",
     packages=['ndindex', 'ndindex.tests'],
-    ext_modules = ext_modules,
+    ext_modules=ext_modules,
     license="MIT",
     install_requires=[
         "numpy",

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
 import os
 import setuptools
 import versioneer
-try:
-    from Cython.Build import cythonize
-except ImportError:
-    pass
 
 
 with open("README.md", "r") as fh:
@@ -12,6 +8,7 @@ with open("README.md", "r") as fh:
 
 ext_modules = []
 if int(os.getenv("CYTHONIZE_NDINDEX", 0)):
+    from Cython.Build import cythonize
     ext_modules.extend(cythonize(["ndindex/*.py"]))
 
 setuptools.setup(

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,11 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 def check_cython():
+    """
+    Check to see if Cython is installed and able to compile extensions (which
+    requires a C compiler and the Python headers to be installed).
+    Return True on success, False on failure.
+    """
     argv_org = list(sys.argv)
     try:
         from Cython.Build import cythonize
@@ -26,10 +31,11 @@ if os.getenv("CYTHONIZE_NDINDEX") is None:
 else:
     CYTHONIZE_NDINDEX = bool(int(os.getenv("CYTHONIZE_NDINDEX")))
 
-ext_modules = []
 if CYTHONIZE_NDINDEX:
     from Cython.Build import cythonize
-    ext_modules.extend(cythonize(["ndindex/*.py"]))
+    ext_modules = cythonize(["ndindex/*.py"])
+else:
+    ext_modules = []
 
 setuptools.setup(
     name="ndindex",

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import setuptools
 import versioneer
 
@@ -6,8 +7,27 @@ import versioneer
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+def check_cython():
+    argv_org = list(sys.argv)
+    try:
+        from Cython.Build import cythonize
+        sys.argv = argv_org[:1] + ["build_ext"]
+        setuptools.setup(name="foo", version="1.0.0",
+                         ext_modules=cythonize(["ndindex/__init__.py"]))
+    except:
+        return False
+    finally:
+        sys.argv = argv_org
+    return True
+
+
+if os.getenv("CYTHONIZE_NDINDEX") is None:
+    CYTHONIZE_NDINDEX = check_cython()
+else:
+    CYTHONIZE_NDINDEX = bool(int(os.getenv("CYTHONIZE_NDINDEX")))
+
 ext_modules = []
-if int(os.getenv("CYTHONIZE_NDINDEX", 0)):
+if CYTHONIZE_NDINDEX:
     from Cython.Build import cythonize
     ext_modules.extend(cythonize(["ndindex/*.py"]))
 
@@ -38,3 +58,5 @@ setuptools.setup(
     ],
     python_requires='>=3.7',
 )
+
+print("CYTHONIZE_NDINDEX: %r" % CYTHONIZE_NDINDEX)

--- a/setup.py
+++ b/setup.py
@@ -4,16 +4,15 @@ import versioneer
 try:
     from Cython.Build import cythonize
 except ImportError:
-    cythonize = None
+    pass
 
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-if cythonize and os.getenv("CYTHONIZE_NDINDEX"):
-    ext_modules = list(cythonize(["ndindex/*.py"]))
-else:
-    ext_modules = []
+ext_modules = []
+if int(os.getenv("CYTHONIZE_NDINDEX", 0)):
+    ext_modules.extend(cythonize(["ndindex/*.py"]))
 
 setuptools.setup(
     name="ndindex",


### PR DESCRIPTION
This PR adds cythonization to all Python models.
When installing ndindex from source (using `python setup.py install`) all
Python modules (except tests) will be cythonized when Cython and a working
compiler are installed.  The environment variable `CYTHONIZE_NDINDEX` is
used to explicitly control this default behavior:

- `CYTHONIZE_NDINDEX=0`: disables cythonization (even if a
  working Cython environment is available)

- `CYTHONIZE_NDINDEX=1`: force cythonization (will fail when Cython or a
  compiler isn't present)

- `CYTHONIZE_NDINDEX` not set: the default behavior

For example, to force cythonization, use:
```
export CYTHONIZE_NDINDEX=1
python setup.py install
```
As versioned HDF5 makes a lot of calls to ndindex, I expect speedups using the cythonized version of ndindex.  For example in https://github.com/deshaw/versioned-hdf5/issues/167 I see a speedup of about 10 to 15%.