### PR TITLE
Fix wrong example in docs for `Integer`

### DIFF
--- a/docs/type-confusion.md
+++ b/docs/type-confusion.md
@@ -188,7 +188,7 @@ Additionally, some advice for specific types:
 
   ```py
   idx = ndindex(0)
-  idx.raw + 1 # Produces an error
+  idx + 1 # Produces an error
   ```
 
 - `Integer` is the only index type that can be used directly as an array


### PR DESCRIPTION
The wrong example showed `idx.raw + 1` as an error. However, this is exactly equal to the example given in the **Right** section. A **Wrong** example should be `idx + 1`, which *does* raise an error.