### PR TITLE
Add Python 3.11 to the GitHub Actions test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
       fail-fast: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This might not actually work yet if the conda packages aren't all built for 3.11.