### PR TITLE
Be more robust with testing against deprecated numpy functionality

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include ndindex/_version.py
 include LICENSE
 include pytest.ini
 include conftest.py
+include run_doctests.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include versioneer.py
 include ndindex/_version.py
 include LICENSE
+include pytest.ini
+include conftest.py

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,9 @@ import numpy
 if LooseVersion(numpy.__version__) < LooseVersion('1.20'):
     raise RuntimeError("NumPy 1.20 (development version) or greater is required to run the ndindex tests")
 
+def pytest_report_header(config):
+    return f"project deps: numpy-{numpy.__version__}"
+
 # Add a --hypothesis-max-examples flag to pytest. See
 # https://github.com/HypothesisWorks/hypothesis/issues/2434#issuecomment-630309150
 

--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -1,7 +1,8 @@
 import sys
 from itertools import chain
-from functools import reduce
+from functools import reduce, wraps
 from operator import mul
+import warnings
 
 from numpy import intp, bool_, array, broadcast_shapes
 import numpy.testing
@@ -181,6 +182,15 @@ def assert_equal(actual, desired, err_msg='', verbose=True):
     assert actual.shape == desired.shape, err_msg or f"{actual.shape} != {desired.shape}"
     assert actual.dtype == desired.dtype, err_msg or f"{actual.dtype} != {desired.dtype}"
 
+def warnings_are_errors(f):
+    @wraps(f)
+    def inner(*args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            return f(*args, **kwargs)
+    return inner
+
+@warnings_are_errors
 def check_same(a, idx, raw_func=lambda a, idx: a[idx],
                ndindex_func=lambda a, index: a[index.raw],
                same_exception=True, assert_equal=assert_equal):

--- a/ndindex/tests/test_as_subindex.py
+++ b/ndindex/tests/test_as_subindex.py
@@ -8,7 +8,7 @@ from hypothesis.strategies import integers, one_of
 from ..ndindex import ndindex
 from ..integerarray import IntegerArray
 from ..tuple import Tuple
-from .helpers import ndindices, short_shapes, assert_equal
+from .helpers import ndindices, short_shapes, assert_equal, warnings_are_errors
 
 @example((slice(0, 8), slice(0, 9), slice(0, 10)),
          ([2, 5, 6, 7], slice(1, 9, 1), slice(5, 10, 1)),
@@ -50,6 +50,7 @@ from .helpers import ndindices, short_shapes, assert_equal
 @example(0, (slice(None, 0, None), Ellipsis), 1)
 @example(0, (slice(1, 2),), 1)
 @given(ndindices, ndindices, one_of(integers(0, 100), short_shapes))
+@warnings_are_errors
 def test_as_subindex_hypothesis(idx1, idx2, shape):
     if isinstance(shape, int):
         a = arange(shape)

--- a/ndindex/tests/test_broadcast_arrays.py
+++ b/ndindex/tests/test_broadcast_arrays.py
@@ -9,7 +9,7 @@ from ..booleanarray import BooleanArray
 from ..integerarray import IntegerArray
 from ..integer import Integer
 from ..tuple import Tuple
-from .helpers import ndindices, check_same, short_shapes
+from .helpers import ndindices, check_same, short_shapes, warnings_are_errors
 
 @example((..., False, False), 1)
 @example((True, False), 1)
@@ -21,6 +21,7 @@ from .helpers import ndindices, check_same, short_shapes
 @example(False, 1)
 @example([[True, False], [False, False]], (2, 2, 3))
 @given(ndindices, one_of(short_shapes, integers(0, 10)))
+@warnings_are_errors
 def test_broadcast_arrays_hypothesis(idx, shape):
     if isinstance(shape, int):
         a = arange(shape)


### PR DESCRIPTION
Previously we only relied on filterwarnings=error in pytest.ini to turn deprecation warnings into errors. We now also do this explicitly in the check_same() function. Also add pytest.ini and conftest.py to the MANIFEST.in so that they are included in the sdist. We still use filterwarnings=error in pytest.ini because we want to make sure we aren't using any other deprecated behavior anywhere else.

Fixes #150.