### PR TITLE
TEST: Disable coverage reporting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,8 @@ jobs:
           set -x
           set -e
 
+          coverage --help
+
           python -We:invalid -We::SyntaxWarning -m compileall -f -q ndindex/
           # The coverage requirement check is done by the coverage report line below
           PYTEST_FLAGS="$PYTEST_FLAGS -v --cov-fail-under=0";

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
           python -We:invalid -We::SyntaxWarning -m compileall -f -q ndindex/
           # The coverage requirement check is done by the coverage report line below
-          # PYTEST_FLAGS="$PYTEST_FLAGS -v --cov-fail-under=0";
+          PYTEST_FLAGS="$PYTEST_FLAGS -v --cov-fail-under=0";
           pytest $PYTEST_FLAGS
           ./run_doctests
           # Make sure it installs
@@ -37,9 +37,9 @@ jobs:
           # Coverage. This also sets the failing status if the
           # coverage is not 100%. Travis sometimes cuts off the last command, which is
           # why we print stuff at the end.
-          # if ! coverage report -m; then
-          #     echo "Coverage failed";
-          #     false;
-          # else
-          #     echo "Coverage passed";
-          # fi;
+          if ! coverage report -m; then
+              echo "Coverage failed";
+              false;
+          else
+              echo "Coverage passed";
+          fi;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
           python -We:invalid -We::SyntaxWarning -m compileall -f -q ndindex/
           # The coverage requirement check is done by the coverage report line below
-          PYTEST_FLAGS="$PYTEST_FLAGS -v --cov-fail-under=0";
+          # PYTEST_FLAGS="$PYTEST_FLAGS -v --cov-fail-under=0";
           pytest $PYTEST_FLAGS
           ./run_doctests
           # Make sure it installs
@@ -37,9 +37,9 @@ jobs:
           # Coverage. This also sets the failing status if the
           # coverage is not 100%. Travis sometimes cuts off the last command, which is
           # why we print stuff at the end.
-          if ! coverage report -m; then
-              echo "Coverage failed";
-              false;
-          else
-              echo "Coverage passed";
-          fi;
+          # if ! coverage report -m; then
+          #     echo "Coverage failed";
+          #     false;
+          # else
+          #     echo "Coverage passed";
+          # fi;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
           set -e
 
           coverage --help
+          coverage debug sys
 
           python -We:invalid -We::SyntaxWarning -m compileall -f -q ndindex/
           # The coverage requirement check is done by the coverage report line below

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --cov=ndindex/ --cov-report=term-missing --flakes --full-trace
+addopts = --flakes --full-trace
 filterwarnings = error

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --flakes --full-trace
+addopts = --cov=ndindex/ --cov-report=term-missing --flakes --full-trace
 filterwarnings = error


### PR DESCRIPTION
Seeing if this is the cause of the Python 3.12 CI tests being so slow.