### PR TITLE
Enable sys.monitoring coverage for Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
             numpy-version: '1.22'
       fail-fast: false
     env:
-      COVERAGE_CORE: sysmon # Enable experimental faster sys.monitoring coverage for Python 3.12
+      COVERAGE_CORE: sysmon #
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -31,6 +31,10 @@ jobs:
           else
               python -m pip install --upgrade numpy==${{ matrix.numpy-version }}.*
           fi
+      # Enable experimental faster sys.monitoring coverage for Python 3.12
+      - name: Set COVERAGE_CORE=sysmon
+        run: echo COVERAGE_CORE=sysmon" >> $GITHUB_ENV
+        if: matrix.python-version == 3.12
       - name: Run Tests
         run: |
           set -x

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12-dev']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         # https://numpy.org/neps/nep-0029-deprecation_policy.html
         numpy-version: ['1.22', 'latest', 'dev']
         exclude:
-          - python-version: '3.12-dev'
+          - python-version: '3.12'
             numpy-version: '1.22'
       fail-fast: false
     steps:
@@ -32,7 +32,7 @@ jobs:
       # Enable experimental faster sys.monitoring coverage for Python 3.12
       - name: Set COVERAGE_CORE=sysmon
         run: echo "COVERAGE_CORE=sysmon" >> $GITHUB_ENV
-        if: matrix.python-version == "3.12-dev"
+        if: matrix.python-version == 3.12
       - name: Run Tests
         run: |
           set -x

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
           python -We:invalid -We::SyntaxWarning -m compileall -f -q ndindex/
           # The coverage requirement check is done by the coverage report line below
-          PYTEST_FLAGS="$PYTEST_FLAGS -v --cov-fail-under=0";
+          # PYTEST_FLAGS="$PYTEST_FLAGS -v --cov-fail-under=0";
           pytest $PYTEST_FLAGS
           ./run_doctests
           # Make sure it installs
@@ -48,9 +48,9 @@ jobs:
           # Coverage. This also sets the failing status if the
           # coverage is not 100%. Travis sometimes cuts off the last command, which is
           # why we print stuff at the end.
-          if ! coverage report -m; then
-              echo "Coverage failed";
-              false;
-          else
-              echo "Coverage passed";
-          fi;
+          # if ! coverage report -m; then
+          #     echo "Coverage failed";
+          #     false;
+          # else
+          #     echo "Coverage passed";
+          # fi;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
           python -We:invalid -We::SyntaxWarning -m compileall -f -q ndindex/
           # The coverage requirement check is done by the coverage report line below
-          # PYTEST_FLAGS="$PYTEST_FLAGS -v --cov-fail-under=0";
+          PYTEST_FLAGS="$PYTEST_FLAGS -v --cov-fail-under=0";
           pytest $PYTEST_FLAGS
           ./run_doctests
           # Make sure it installs
@@ -48,9 +48,9 @@ jobs:
           # Coverage. This also sets the failing status if the
           # coverage is not 100%. Travis sometimes cuts off the last command, which is
           # why we print stuff at the end.
-          # if ! coverage report -m; then
-          #     echo "Coverage failed";
-          #     false;
-          # else
-          #     echo "Coverage passed";
-          # fi;
+          if ! coverage report -m; then
+              echo "Coverage failed";
+              false;
+          else
+              echo "Coverage passed";
+          fi;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
           fi
       # Enable experimental faster sys.monitoring coverage for Python 3.12
       - name: Set COVERAGE_CORE=sysmon
-        run: echo COVERAGE_CORE=sysmon" >> $GITHUB_ENV
+        run: echo "COVERAGE_CORE=sysmon" >> $GITHUB_ENV
         if: matrix.python-version == 3.12
       - name: Run Tests
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ jobs:
           - python-version: '3.12-dev'
             numpy-version: '1.22'
       fail-fast: false
+    env:
+      COVERAGE_CORE: sysmon # Enable experimental faster sys.monitoring coverage for Python 3.12
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
       # Enable experimental faster sys.monitoring coverage for Python 3.12
       - name: Set COVERAGE_CORE=sysmon
         run: echo "COVERAGE_CORE=sysmon" >> $GITHUB_ENV
-        if: matrix.python-version == 3.12
+        if: matrix.python-version == "3.12-dev"
       - name: Run Tests
         run: |
           set -x

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,6 @@ jobs:
           - python-version: '3.12-dev'
             numpy-version: '1.22'
       fail-fast: false
-    env:
-      COVERAGE_CORE: sysmon #
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --cov=ndindex/ --cov-report=term-missing --flakes --full-trace
+addopts = --flakes --full-trace
 filterwarnings = error

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --flakes --full-trace
+addopts = --cov=ndindex/ --cov-report=term-missing --flakes --full-trace
 filterwarnings = error


### PR DESCRIPTION
This should make the 3.12 tests run as fast or faster than the 3.11 tests.