### PR TITLE
Incorrect use of comma (,) before which

### DIFF
--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -14,7 +14,7 @@ This is a style guide for the ndindex documentation.
   `NDIndex` base class.
 - The plural of "index" is "indices". "Indexes" should only be used as a verb.
   For example, "in `a[i, j]`, the indices are `i` and `j`. They represent a
-  single tuple index `(i, j)`, which indexes the array `a`."
+  single tuple index `(i, j)` which indexes the array `a`."
 - The arguments of a slice should be referred to as "start", "stop", and
   "step", respectively. This matches the argument names and attributes of the
   `Slice` and `slice` objects.


### PR DESCRIPTION
I noticed a grammatical issue in the documentation.
There are very specific cases where a comma must be used before 'which'. This is not one of those cases. The sentence in question uses a `restrictive clause`. Commas are used before, and to separate out, `non-restrictive clauses`.

[Read more here](https://www.grammarly.com/blog/punctuation-capitalization/comma-before-which/)

Another way is to use the word `that` instead of `which`. One is less inclined to make a mistake using that word and it serves the same purpose.

The sentence would look like:


> They represent a single tuple index `(i, j)` **that** indexes the array `a`.
