### PR TITLE
ENH: Free threading support

### DIFF
--- a/.github/workflows/freethreading_tests.yml
+++ b/.github/workflows/freethreading_tests.yml
@@ -1,0 +1,31 @@
+name: Free Threading Tests
+on: [push, pull_request]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "0.7.2"
+          python-version: 3.13t
+          enable-cache: false
+      - name: Set up Python
+        run: uv python install
+      - name: Install Dependencies
+        run: |
+          uv pip install numpy pytest-cov pytest-timeout pytest-durations pytest-run-parallel sympy hypothesis
+      - name: Disable Coverage # see gh-198
+        run: |
+          sed -i '/plugins = Cython.Coverage/d' .coveragerc
+          sed -i 's/addopts/\#addopts/' pytest.ini
+      - name: Editable build
+        run: |
+          uv pip install -v -e .
+      - name: Run Tests
+        run: |
+          set -xe
+          uv run --no-project python -We:invalid -We::SyntaxWarning -m compileall -f -q ndindex/
+          uv run --no-project python -m pytest --parallel-threads=2 --iterations=2 -v -s \
+                 --timeout=600 --durations=10 -m "not hypothesis and not thread_unsafe and not flakes"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -89,7 +89,7 @@ jobs:
         run: echo "SDIST_FILE=$(ls dist/*.tar.gz)" >> $GITHUB_ENV
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.0
+        uses: pypa/cibuildwheel@v2.23.3
         with:
           package-dir: ${{ env.SDIST_FILE }}
           output-dir: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ dmypy.json
 # Cython
 ndindex/*.c
 ndindex/*.html
+ndindex/*.cpp

--- a/ndindex/_slice.pyx
+++ b/ndindex/_slice.pyx
@@ -8,20 +8,20 @@ cdef extern from "Python.h":
     bint PyBool_Check(object obj)
     int64_t PyLong_AsLongLong(object obj) except? -1
 
+# Module scope, so implicitly thread safe
+# xref: https://github.com/Quansight-Labs/ndindex/pull/199#discussion_r2072395630
 cdef bint _NUMPY_IMPORTED = False
 cdef type _NUMPY_BOOL = None
+global _NUMPY_IMPORTED, _NUMPY_BOOL
+if not _NUMPY_IMPORTED:
+    if 'numpy' in sys.modules:
+        _NUMPY_BOOL = sys.modules['numpy'].bool_
+    _NUMPY_IMPORTED = True
 
 cdef inline bint is_numpy_bool(object obj):
-    global _NUMPY_IMPORTED, _NUMPY_BOOL
-    if not _NUMPY_IMPORTED:
-        if 'numpy' in sys.modules:
-            _NUMPY_BOOL = sys.modules['numpy'].bool_
-        _NUMPY_IMPORTED = True
     return _NUMPY_BOOL is not None and isinstance(obj, _NUMPY_BOOL)
 
 cdef inline int64_t cy_operator_index(object idx) except? -1:
-    cdef object result
-
     if PyBool_Check(idx) or is_numpy_bool(idx):
         raise TypeError(f"'{type(idx).__name__}' object cannot be interpreted as an integer")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ["setuptools", "cython", "versioneer"]
 build-backend = "setuptools.build_meta"
+[tool.cibuildwheel]
+enable = ["cpython-freethreading"]
+skip = "*t*_i686"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,13 @@
 [build-system]
-requires = ["setuptools", "cython", "versioneer"]
+requires = [
+    # Pin to an older setuptools version for PyPy only, due to pypa/distutils#283
+    "setuptools; platform_python_implementation != 'PyPy'",
+    "setuptools<72.2; platform_python_implementation == 'PyPy'",
+    "cython",
+    "versioneer"
+]
 build-backend = "setuptools.build_meta"
+
 [tool.cibuildwheel]
 enable = ["cpython-freethreading"]
 skip = "*t*_i686"


### PR DESCRIPTION
Closes #198. Basically:
- Uses ~a critical section~ module scope for `global` cache variables in Cython
  - ~With the slow-and-fast path structuring recommended in the [ft-guide](https://py-free-threading.github.io/porting/)~
- Uses C++ threading primitives (through Cython wrappers) for managing lazy imports
- Signals to Cython that the code is indeed safe for `ft` builds
- ~Splits the `global` sections out into their own files since earlier `cython` versions cannot handle `critical_section`~ Uses conditional compilation via `IF`now. 

Draft until I get the CI right for
- [x] testing and 
- [x] building wheels. 

The testing bit is mostly taken from this recent [NumPy PR](https://github.com/numpy/numpy/pull/28808), but since there aren't any tests which use `threading` (nor AFAIK should there be, the NDIndex objects seem pretty immutable), might not even need the `TSAN` run.