### PR TITLE
Fix CI issues, minor issues in pyproject.toml, and a deprecation warning for license classifier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,9 +40,12 @@ jobs:
         # https://github.com/nedbat/coveragepy/issues/1665), just omit Cython
         # coverage in 3.12. Hopefully by the time it is our minimal version it
         # will work with Cython, or trace coverage will be faster again.
-      - name: Set CYTHON_COVERAGE=1
-        run: echo "CYTHON_COVERAGE=1" >> $GITHUB_ENV
+      - name: Set CYTHON_COVERAGE=1 and install Cython 3.0
         if: contains(fromJSON('["3.9", "3.10", "3.11"]'), matrix.python-version)
+        run: |
+          echo "CYTHON_COVERAGE=1" >> $GITHUB_ENV
+          # Cython 3.1.0 broke coverage usage, so install 3.0.x (see gh-203)
+          python -m pip install "Cython<3.1.0"
       - name: Disable Coverage Plugin
         run: sed -i '/plugins = Cython.Coverage/d' .coveragerc
         if: contains(fromJSON('["3.12", "3.13", "3.14-dev"]'), matrix.python-version)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
           set -x
           set -e
           python -m pip install -r requirements-dev.txt
+          python -m pip install -U setuptools
           if [[ ${{ matrix.numpy-version }} == 'latest' ]]; then
               python -m pip install --upgrade numpy
           elif [[ ${{ matrix.numpy-version }} == 'dev' ]]; then
@@ -33,9 +34,7 @@ jobs:
           else
               python -m pip install --upgrade numpy==${{ matrix.numpy-version }}.*
           fi
-      - name: Test Installation
-        run: |
-          python -m pip install --verbose .
+  
         # COVERAGE_CORE=sysmon does not work with Cython. Since coverage is
         # really slow without it (see
         # https://github.com/nedbat/coveragepy/issues/1665), just omit Cython
@@ -43,14 +42,13 @@ jobs:
         # will work with Cython, or trace coverage will be faster again.
       - name: Set CYTHON_COVERAGE=1
         run: echo "CYTHON_COVERAGE=1" >> $GITHUB_ENV
-        if: !contains(fromJson('["3.12", "3.13", "3.14-dev"]'), matrix.python-version)
+        if: contains(fromJSON('["3.9", "3.10", "3.11"]'), matrix.python-version)
       - name: Disable Coverage Plugin
         run: sed -i '/plugins = Cython.Coverage/d' .coveragerc
-        if: contains(fromJson('["3.12", "3.13", "3.14-dev"]'), matrix.python-version)
+        if: contains(fromJSON('["3.12", "3.13", "3.14-dev"]'), matrix.python-version)
       - name: In-place build
         run: |
-          python setup.py clean
-          python setup.py build_ext --inplace
+          python -m pip install --verbose -e . --no-build-isolation
       - name: Run Doctests
         run: |
           ./run_doctests
@@ -64,7 +62,7 @@ jobs:
       # Enable experimental faster sys.monitoring coverage for Python 3.12
       - name: Set COVERAGE_CORE=sysmon
         run: echo "COVERAGE_CORE=sysmon" >> $GITHUB_ENV
-        if: contains(fromJson('["3.12", "3.13", "3.14-dev"]'), matrix.python-version)
+        if: contains(fromJSON('["3.12", "3.13", "3.14-dev"]'), matrix.python-version)
       - name: Run Tests
         run: |
           set -x

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,18 +5,20 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13-dev']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']  # add 3.14-dev once numpy/skimage have wheels available
         # https://numpy.org/neps/nep-0029-deprecation_policy.html
         numpy-version: ['1.22', 'latest', 'dev']
         exclude:
           - python-version: '3.12'
             numpy-version: '1.22'
-          - python-version: '3.13-dev'
+          - python-version: '3.13'
+            numpy-version: '1.22'
+          - python-version: '3.14-dev'
             numpy-version: '1.22'
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
@@ -41,10 +43,10 @@ jobs:
         # will work with Cython, or trace coverage will be faster again.
       - name: Set CYTHON_COVERAGE=1
         run: echo "CYTHON_COVERAGE=1" >> $GITHUB_ENV
-        if: matrix.python-version != '3.12' && matrix.python-version != '3.13-dev'
+        if: !contains(fromJson('["3.12", "3.13", "3.14-dev"]'), matrix.python-version)
       - name: Disable Coverage Plugin
         run: sed -i '/plugins = Cython.Coverage/d' .coveragerc
-        if: matrix.python-version == '3.12' || matrix.python-version == '3.13-dev'
+        if: contains(fromJson('["3.12", "3.13", "3.14-dev"]'), matrix.python-version)
       - name: In-place build
         run: |
           python setup.py clean
@@ -62,7 +64,7 @@ jobs:
       # Enable experimental faster sys.monitoring coverage for Python 3.12
       - name: Set COVERAGE_CORE=sysmon
         run: echo "COVERAGE_CORE=sysmon" >> $GITHUB_ENV
-        if: matrix.python-version == '3.12' || matrix.python-version == '3.13-dev'
+        if: contains(fromJson('["3.12", "3.13", "3.14-dev"]'), matrix.python-version)
       - name: Run Tests
         run: |
           set -x

--- a/ndindex/tests/helpers.py
+++ b/ndindex/tests/helpers.py
@@ -468,7 +468,7 @@ def check_same(a, idx, *, raw_func=lambda a, idx: a[idx],
                 if ("Using a non-tuple sequence for multidimensional indexing is deprecated" in w.args[0]): # pragma: no cover
                     idx = asarray(idx, dtype=intp)
                     a_raw = raw_func(a, idx)
-                elif "Out of bound index found. This was previously ignored when the indexing result contained no elements. In the future the index error will be raised. This error occurs either due to an empty slice, or if an array has zero elements even before indexing." in w.args[0]:
+                elif "Out of bound index found. This was previously ignored when the indexing result contained no elements. In the future the index error will be raised. This error occurs either due to an empty slice, or if an array has zero elements even before indexing." in w.args[0]: # pragma: no cover
                     same_exception = False
                     raise IndexError
                 else: # pragma: no cover

--- a/ndindex/tests/test_broadcast_arrays.py
+++ b/ndindex/tests/test_broadcast_arrays.py
@@ -43,7 +43,7 @@ def test_broadcast_arrays_hypothesis(idx, shape):
             # Integers are bounds checked even when the resulting index
             # broadcasts to empty (but not so for IntegerArray).
             check = False
-    except DeprecationWarning as w:
+    except DeprecationWarning as w: # pragma: no cover
         if "Out of bound index found. This was previously ignored when the indexing result contained no elements. In the future the index error will be raised. This error occurs either due to an empty slice, or if an array has zero elements even before indexing." in w.args[0]:
             pass
         else: # pragma: no cover

--- a/ndindex/tests/test_isvalid.py
+++ b/ndindex/tests/test_isvalid.py
@@ -27,7 +27,7 @@ def test_isvalid_hypothesis(idx, shape):
         except Warning as w:
             # check_same unconditionally turns this warning into raise
             # IndexError, so we have to handle it separately here.
-            if "Out of bound index found. This was previously ignored when the indexing result contained no elements. In the future the index error will be raised. This error occurs either due to an empty slice, or if an array has zero elements even before indexing." in w.args[0]:
+            if "Out of bound index found. This was previously ignored when the indexing result contained no elements. In the future the index error will be raised. This error occurs either due to an empty slice, or if an array has zero elements even before indexing." in w.args[0]: # pragma: no cover
                 return False
             raise # pragma: no cover
         except IndexError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "cython"]
+requires = ["setuptools", "cython", "versioneer"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ["setuptools", "cython"]
+build-backend = "setuptools.build_meta"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
 Cython
+setuptools
+versioneer
 hypothesis
 matplotlib
 numpy

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup(
     },
     classifiers=[
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.9',


### PR DESCRIPTION
The commit message contains the warning that was emitted. `setuptools` has deprecated license classifiers completely.