### PR TITLE
CI: Use xdist for faster tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
 
           python -We:invalid -We::SyntaxWarning -m compileall -f -q ndindex/
           # The coverage requirement check is done by the coverage report line below
-          PYTEST_FLAGS="$PYTEST_FLAGS -v --cov-fail-under=0";
+          PYTEST_FLAGS="$PYTEST_FLAGS -v --cov-fail-under=0 -n auto";
           pytest $PYTEST_FLAGS
           # Coverage. This also sets the failing status if the
           # coverage is not 100%. Travis sometimes cuts off the last command, which is

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ pyflakes
 pytest
 pytest-cov
 pytest-doctestplus
+pytest-xdist
 pytest-flakes
 scikit-image
 slotscheck


### PR DESCRIPTION
Minor PR but can be helpful, locally tests take half the time and it has a pretty decent speed up on CI here (around 30-40%)