### PR TITLE
Bump the GitHub Actions for uploading releases to latest versions

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -133,19 +133,19 @@ jobs:
       #
       # Compare to 'true' string as booleans get turned into strings in the console
       if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true'
-      uses: pypa/gh-action-pypi-publish@v1.8.11
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
         repository-url: https://test.pypi.org/legacy/
         print-hash: true
 
     - name: Create GitHub Release from a Tag
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2.2.2
       if: startsWith(github.ref, 'refs/tags/')
       with:
           files: dist/*
 
     - name: Publish distribution 📦 to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.8.11
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
         print-hash: true


### PR DESCRIPTION
This resolves the issue with not being able to upload the release to PyPI due to metadata version too new (xref gh-208).